### PR TITLE
Fix text annotations and more

### DIFF
--- a/export_presentation.rb
+++ b/export_presentation.rb
@@ -61,6 +61,8 @@ BENCHMARK = BENCHMARK_FFMPEG ? "-benchmark " : ""
 
 THREADS = 4
 
+CURSOR_RADIUS = 8
+
 # Output video size
 OUTPUT_WIDTH = 1920
 OUTPUT_HEIGHT = 1080
@@ -522,8 +524,8 @@ def render_cursor(panzooms, cursor_reader)
   builder = Builder::XmlMarkup.new
 
   # Add 'xmlns' => 'http://www.w3.org/2000/svg' for visual debugging, remove for faster exports
-  builder.svg(width: "16", height: "16") do
-    builder.circle(cx: "8", cy: "8", r: "8", fill: "red")
+  builder.svg(width: CURSOR_RADIUS * 2, height: CURSOR_RADIUS * 2) do
+    builder.circle(cx: CURSOR_RADIUS, cy: CURSOR_RADIUS, r: CURSOR_RADIUS, fill: "red")
   end
 
   File.open("#{@published_files}/cursor/cursor.svg", "w", TEMPORARY_FILES_PERMISSION) do |svg|
@@ -580,8 +582,8 @@ def render_cursor(panzooms, cursor_reader)
       y_offset = (SLIDES_HEIGHT - (scale_factor * height)) / 2
 
       # Center cursor
-      cursor_x -= 8
-      cursor_y -= 8
+      cursor_x -= CURSOR_RADIUS
+      cursor_y -= CURSOR_RADIUS
 
       cursor_x += x_offset
       cursor_y += y_offset

--- a/export_presentation.rb
+++ b/export_presentation.rb
@@ -18,12 +18,13 @@ include IntervalTree
 
 opts = Trollop.options do
   opt :meeting_id, "Meeting id to archive", type: String
+  opt :log_stdout, "Log to STDOUT", :type => :flag
   opt :format, "Playback format name", type: String
 end
 
 meeting_id = opts[:meeting_id]
 
-logger = Logger.new("/var/log/bigbluebutton/post_publish.log", 'weekly')
+logger = opts[:log_stdout] ? Logger.new(STDOUT) : Logger.new("/var/log/bigbluebutton/post_publish.log", 'weekly' )
 logger.level = Logger::INFO
 BigBlueButton.logger = logger
 

--- a/export_presentation.rb
+++ b/export_presentation.rb
@@ -61,6 +61,8 @@ BENCHMARK = BENCHMARK_FFMPEG ? "-benchmark " : ""
 
 THREADS = 4
 
+BACKGROUND_COLOR = "white"
+
 CURSOR_RADIUS = 8
 
 # Output video size
@@ -663,7 +665,7 @@ def render_video(duration, meeting_name)
   deskshare = !HIDE_DESKSHARE && File.file?("#{@published_files}/deskshare/deskshare.#{VIDEO_EXTENSION}")
   chat = !HIDE_CHAT && File.file?("#{@published_files}/chats/chat.svg")
 
-  render = "ffmpeg -f lavfi -i color=c=white:s=#{OUTPUT_WIDTH}x#{OUTPUT_HEIGHT} " \
+  render = "ffmpeg -f lavfi -i color=c=#{BACKGROUND_COLOR}:s=#{OUTPUT_WIDTH}x#{OUTPUT_HEIGHT} " \
            "-f concat -safe 0 #{BASE_URI} -i #{@published_files}/timestamps/whiteboard_timestamps " \
            "-framerate 10 -loop 1 -i #{@published_files}/cursor/cursor.svg "
 

--- a/export_presentation.rb
+++ b/export_presentation.rb
@@ -19,7 +19,6 @@ include IntervalTree
 opts = Trollop.options do
   opt :meeting_id, "Meeting id to archive", type: String
   opt :log_stdout, "Log to STDOUT", :type => :flag
-  opt :format, "Playback format name", type: String
 end
 
 meeting_id = opts[:meeting_id]

--- a/export_presentation.rb
+++ b/export_presentation.rb
@@ -106,8 +106,8 @@ DESKSHARE_Y_OFFSET = ((SLIDES_HEIGHT -
 WhiteboardElement = Struct.new(:begin, :end, :value, :id)
 WhiteboardSlide = Struct.new(:href, :begin, :end, :width, :height)
 
-def run_command(command)
-  BigBlueButton.logger.info("Running: #{command}")
+def run_command(command, silent = false)
+  BigBlueButton.logger.info("Running: #{command}") unless silent
   output = `#{command}`
   [ $?.success?, output ]
 end
@@ -217,7 +217,7 @@ def measure_string(s, font_size)
   # /usr/share/fonts/truetype/dejavu/DejaVuSans.ttf
   # use ImageMagick to measure the string in pixels
   command = "convert xc: -font /usr/share/fonts/truetype/msttcorefonts/Arial.ttf -pointsize #{font_size} -debug annotate -annotate 0 '#{s}' null: 2>&1"
-  _, output = run_command(command)
+  _, output = run_command(command, true)
   output.match(/; width: (\d+);/)[1].to_f
 end
 


### PR DESCRIPTION
- chore: add option to silently run a commando using run_command, since convert executes too often
- chore: move background color to a constant
- fix: svg placement in order to match the same visibility area of the document as bbb-playback
- fix: improve text annotations
- chore: use helper function to execute commands, so we can log what's being executed
- chore: move cursor radius to a constant
- chore: remove unused parameter --format
- chore: move temporary files permission to constant; rename FILE_EXTENSION to SVG_EXTENSION
- feat: add new parameter to redirect logs to stdout